### PR TITLE
read clib file in both ini and yaml format

### DIFF
--- a/include/aruco_mapping.h
+++ b/include/aruco_mapping.h
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Standard ROS libraries
 #include <ros/ros.h>
 #include <sensor_msgs/image_encodings.h>
-#include <camera_calibration_parsers/parse_ini.h>
+#include <camera_calibration_parsers/parse.h>
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/Marker.h>

--- a/src/aruco_mapping.cpp
+++ b/src/aruco_mapping.cpp
@@ -116,7 +116,7 @@ ArucoMapping::parseCalibrationFile(std::string calib_filename)
   sensor_msgs::CameraInfo camera_calibration_data;
   std::string camera_name = "camera";
 
-  camera_calibration_parsers::readCalibrationIni(calib_filename, camera_name, camera_calibration_data);
+  camera_calibration_parsers::readCalibration(calib_filename, camera_name, camera_calibration_data);
 
   // Alocation of memory for calibration data
   cv::Mat  *intrinsics       = new(cv::Mat)(3, 3, CV_64F);


### PR DESCRIPTION
It should be possible to read the configuration file as both ini and yaml; this is already supported in `camera_calibration_parsers`.