### PR TITLE
fix: Typo in aruco_mapping.cpp Line 61

### DIFF
--- a/include/aruco_mapping.h
+++ b/include/aruco_mapping.h
@@ -151,18 +151,18 @@ private:
    static const int CV_WAIT_KEY = 10;
    static const int CV_WINDOW_MARKER_LINE_WIDTH = 2;
 
-   static const double WAIT_FOR_TRANSFORM_INTERVAL = 2.0;
-   static const double BROADCAST_WAIT_INTERVAL = 0.0001;
-   static const double INIT_MIN_SIZE_VALUE = 1000000;
+   static constexpr double WAIT_FOR_TRANSFORM_INTERVAL = 2.0;
+   static constexpr double BROADCAST_WAIT_INTERVAL = 0.0001;
+   static constexpr double INIT_MIN_SIZE_VALUE = 1000000;
 
-   static const double RVIZ_MARKER_HEIGHT = 0.01;
-   static const double RVIZ_MARKER_LIFETIME = 0.2;
-   static const double RVIZ_MARKER_COLOR_R = 1.0;
-   static const double RVIZ_MARKER_COLOR_G = 1.0;
-   static const double RVIZ_MARKER_COLOR_B = 1.0;
-   static const double RVIZ_MARKER_COLOR_A = 1.0;
+   static constexpr double RVIZ_MARKER_HEIGHT = 0.01;
+   static constexpr double RVIZ_MARKER_LIFETIME = 0.2;
+   static constexpr double RVIZ_MARKER_COLOR_R = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_G = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_B = 1.0;
+   static constexpr double RVIZ_MARKER_COLOR_A = 1.0;
 
-   static const double THIS_IS_FIRST_MARKER = -2;
+   static constexpr double THIS_IS_FIRST_MARKER = -2;
 
 }; //ArucoMapping class
 }  //aruco_mapping namespace

--- a/src/aruco_mapping.cpp
+++ b/src/aruco_mapping.cpp
@@ -40,34 +40,34 @@ namespace aruco_mapping
 {
 
 ArucoMapping::ArucoMapping(ros::NodeHandle *nh) :
-  listener_ (new tf::TransformListener),  // Initialize TF Listener  
+  listener_ (new tf::TransformListener),  // Initialize TF Listener
   num_of_markers_ (10),                   // Number of used markers
   marker_size_(0.1),                      // Marker size in m
   calib_filename_("empty"),               // Calibration filepath
-  space_type_ ("plane"),                  // Space type - 2D plane 
+  space_type_ ("plane"),                  // Space type - 2D plane
   roi_allowed_ (false),                   // ROI not allowed by default
   first_marker_detected_(false),          // First marker not detected by defualt
   lowest_marker_id_(-1),                  // Lowest marker ID
   marker_counter_(0),                     // Reset marker counter
-  closest_camera_index_(0)                // Reset closest camera index 
-  
+  closest_camera_index_(0)                // Reset closest camera index
+
 {
-  double temp_marker_size;  
-  
-  //Parse params from launch file 
+  double temp_marker_size;
+
+  //Parse params from launch file
   nh->getParam("/aruco_mapping/calibration_file", calib_filename_);
-  nh->getParam("/aruco_mapping/marker_size", temp_marker_size); 
+  nh->getParam("/aruco_mapping/marker_size", temp_marker_size);
   nh->getParam("/aruco_mapping/num_of_markers", num_of_markers_);
-  nh->getParam("/aruco_maping/space_type",space_type_);
+  nh->getParam("/aruco_mapping/space_type", space_type_);
   nh->getParam("/aruco_mapping/roi_allowed",roi_allowed_);
   nh->getParam("/aruco_mapping/roi_x",roi_x_);
   nh->getParam("/aruco_mapping/roi_y",roi_y_);
   nh->getParam("/aruco_mapping/roi_w",roi_w_);
   nh->getParam("/aruco_mapping/roi_h",roi_h_);
-     
+
   // Double to float conversion
   marker_size_ = float(temp_marker_size);
-  
+
   if(calib_filename_ == "empty")
     ROS_WARN("Calibration filename empty! Check the launch file paths");
   else
@@ -80,22 +80,22 @@ ArucoMapping::ArucoMapping(ros::NodeHandle *nh) :
     ROS_INFO_STREAM("ROI x-coor: " << roi_x_);
     ROS_INFO_STREAM("ROI y-coor: " << roi_x_);
     ROS_INFO_STREAM("ROI width: "  << roi_w_);
-    ROS_INFO_STREAM("ROI height: " << roi_h_);      
+    ROS_INFO_STREAM("ROI height: " << roi_h_);
   }
-    
+
   //ROS publishers
   marker_msg_pub_           = nh->advertise<aruco_mapping::ArucoMarker>("aruco_poses",1);
   marker_visualization_pub_ = nh->advertise<visualization_msgs::Marker>("aruco_markers",1);
-          
+
   //Parse data from calibration file
   parseCalibrationFile(calib_filename_);
 
   //Initialize OpenCV window
-  cv::namedWindow("Mono8", CV_WINDOW_AUTOSIZE);       
-      
+  cv::namedWindow("Mono8", CV_WINDOW_AUTOSIZE);
+
   //Resize marker container
   markers_.resize(num_of_markers_);
-  
+
   // Default markers_ initialization
   for(size_t i = 0; i < num_of_markers_;i++)
   {
@@ -169,20 +169,20 @@ ArucoMapping::imageCallback(const sensor_msgs::ImageConstPtr &original_image)
     ROS_ERROR("Not able to convert sensor_msgs::Image to OpenCV::Mat format %s", e.what());
     return;
   }
-  
+
   // sensor_msgs::Image to OpenCV Mat structure
   cv::Mat I = cv_ptr->image;
-  
+
   // region of interest
   if(roi_allowed_==true)
     I = cv_ptr->image(cv::Rect(roi_x_,roi_y_,roi_w_,roi_h_));
 
   //Marker detection
   processImage(I,I);
-  
+
   // Show image
   cv::imshow("Mono8", I);
-  cv::waitKey(10);  
+  cv::waitKey(10);
 }
 
 
@@ -201,7 +201,7 @@ ArucoMapping::processImage(cv::Mat input_image,cv::Mat output_image)
 
   // Detect markers
   Detector.detect(input_image,temp_markers,aruco_calib_params_,marker_size_);
-    
+
   // If no marker found, print statement
   if(temp_markers.size() == 0)
     ROS_DEBUG("No marker found!");
@@ -612,7 +612,7 @@ ArucoMapping::processImage(cv::Mat input_image,cv::Mat output_image)
       if(markers_[j].visible == true)
       {
         marker_msg.marker_ids.push_back(markers_[j].marker_id);
-        marker_msg.global_marker_poses.push_back(markers_[j].geometry_msg_to_world);       
+        marker_msg.global_marker_poses.push_back(markers_[j].geometry_msg_to_world);
       }
     }
   }


### PR DESCRIPTION
Fixed **space_type_** parameter was not loaded from launch file due to typo in aruco_mapping.cpp Line 61.

Original code:
nh->getParam("/aruco_maping/space_type",space_type_);

Fixed:
nh->getParam("/aruco_mapping/space_type",space_type_);

Issue #8 